### PR TITLE
修正產生圖片 endpoint 判斷，確保不與靜態資源衝突

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export default {
 				return await handleSubRouteAPI(modifiedUrl, env);
 			}
 
-			if (url.pathname.endsWith('.png')) {
+			if (url.pathname.match(/^\/[^\/]+\.png$/)) {
 				return await handleImageGeneration(url, env);
 			}
 


### PR DESCRIPTION
目前產生圖片的 endpoint (如: `/萌.png`) 與 png 靜態資源 (如: `/images/萌.png`) 會產生衝突，目前只要是 .png 結尾都會產成圖片

ex:
https://cf-moedict-webkit.audreyt.workers.dev/images/萌.png
![image](https://cf-moedict-webkit.audreyt.workers.dev/images/萌.png)

這個 PR 修改了產生圖片 endpoint 的正則表達式，確保只有在根目錄下的 .png 請求會被轉為圖片

![1761121746934](https://github.com/user-attachments/assets/0c6f8852-4bf7-4654-9c75-9d82239ac0ba)

